### PR TITLE
Release note gen v16

### DIFF
--- a/.github/workflows/test-update-pr.yml
+++ b/.github/workflows/test-update-pr.yml
@@ -11,6 +11,8 @@ jobs:
 
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Generate PR description
         uses: vblagoje/auto-pr@main

--- a/.github/workflows/test-update-pr.yml
+++ b/.github/workflows/test-update-pr.yml
@@ -2,24 +2,11 @@ name: Test Workflow
 
 on:
   pull_request:
-    types: [opened, edited, reopened]
-  issue_comment:
-    types: [created]
+    types: [opened]
 
 jobs:
-  test-pr-update-on-opened-pr:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-
-      - name: Update PR description
-        uses: vblagoje/update-pr@v1
-        with:
-          pr-body: Let's merge ${{ github.event.pull_request.head.ref }} into ${{ github.event.pull_request.base.ref }}
-
   create-pr-release-note:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     steps:
 
       - name: Checkout Repository
@@ -27,16 +14,28 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
+      - name: Generate PR description
+        uses: vblagoje/auto-pr@main
+        id: auto-pr
+        with:
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+
+      - name: Update PR description
+        uses: vblagoje/update-pr@main
+        with:
+          pr-body: ${{steps.auto-pr.outputs.pr-text}}
+
+      - name: Generate Release Note for this PR
+        uses: vblagoje/auto-reno@main
+        id: auto-reno
+        with:
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+
       - name: Create PR release note
         uses: vblagoje/create-or-update-release-note@main
         with:
-          note-name: test-note-added-by-workflow
-          note-content: |
-            ---
-            preview:
-              - |
-                Some release note content. Testing testing.
-
+          note-name: ${{steps.auto-reno.outputs.file-name}}
+          note-content: ${{steps.auto-reno.outputs.note}}
 
   find-pr-release-note-on-opened-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-update-pr.yml
+++ b/.github/workflows/test-update-pr.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
 
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/test-update-pr.yml
+++ b/.github/workflows/test-update-pr.yml
@@ -12,7 +12,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Generate PR description
         uses: vblagoje/auto-pr@main

--- a/.github/workflows/test-update-pr.yml
+++ b/.github/workflows/test-update-pr.yml
@@ -11,8 +11,6 @@ jobs:
 
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Generate PR description
         uses: vblagoje/auto-pr@main

--- a/releasenotes/notes/automate-pr-description-release-notes-ecb6866917a22d59.yaml
+++ b/releasenotes/notes/automate-pr-description-release-notes-ecb6866917a22d59.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+ - |
+   Enhanced the PR workflow by automating the generation and updating of PR descriptions and release notes using AI. Changes include simplifying the workflow triggers, introducing auto-generation of PR descriptions, and automating release note creation with extracted file names and content for a smoother experience in managing pull requests.


### PR DESCRIPTION
### Why:
The Pull Request addresses the automation enhancement for the project's GitHub workflow. It streamlines the process of updating a PR's description, automating release note generation, and handling PR events more efficiently. By refining the types of pull request events that trigger the workflow and updating the actions used, this change improves consistency and minimizes manual intervention, enabling a smoother and more reliable development process.

### What:
- Changed the trigger types for `pull_request` events to only `opened`, removing `edited` and `reopened`.
- Replaced the `issue_comment` trigger with specific pull_request event types.
- Renamed the `test-pr-update-on-opened-pr` job to `create-pr-release-note`.
- Updated the `Checkout Repository` action to version 4 and adjusted its parameters for better context resolution.
- Added a new step that generates a PR description using `vblagoje/auto-pr` action.
- Updated the `Update PR description` action to use dynamic content from the `auto-pr` output.
- Introduced a new step that generates a release note using `vblagoje/auto-reno` action.
- Updated `Create PR release note` action to use dynamic content from `auto-reno` output.

### How can it be used:
- Automatically update PR descriptions with a generated message detailing the changes from the PR's branch to the base branch.
  ```yaml
  - name: Update PR description
    uses: vblagoje/update-pr@main
    with:
      pr-body: ${{steps.auto-pr.outputs.pr-text}}
  ```
- Generate and append release notes for the PR without manual content creation.
  ```yaml
  - name: Generate Release Note for this PR
    uses: vblagoje/auto-reno@main
    with:
      openai_api_key: ${{ secrets.OPENAI_API_KEY }}
  ```
- Reduce the redundancy in responding to pull request events to trigger only on new PRs.
  
### How did you test it:
Not explicitly stated, but typically this involves:
- Ensuring that the workflow is triggered correctly by the `opened` PR event.
- Validating that the PR description is updated with the correct information from the `auto-pr` step.
- Confirming that release notes are generated and populated correctly using `auto-reno`.

Additional tests might include:
- Testing other PR event types (`edited`, `reopened`) to ensure they do not trigger the workflow unintentionally.
- Verifying that the updated actions are compatible with the rest of the workflow, such as branch protection rules or merge strategies.

### Notes for the reviewer:
- The `fetch-depth: 0` in the `Checkout Repository` step is crucial to ensure a full clone of the repository is performed, which may be necessary for some actions to work correctly.
- Reviewers should verify that the `secrets.OPENAI_API_KEY` is appropriately configured for the project to enable the new automatic description and release note generation features.
- It would be beneficial to ensure that the newly introduced actions (`auto-pr` and `auto-reno`) have adequate error handling and feedback mechanisms for when the automated generation processes fail.
- The compatibility of the updated actions (`update-pr` moving from `v1` to `main`, and `checkout` from `v2` to `v4`) with existing workflow assumptions should be verified.