### PR TITLE
feat: Use fireworks LLMs

### DIFF
--- a/.github/workflows/test-update-pr.yml
+++ b/.github/workflows/test-update-pr.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           openai_base_url: https://api.fireworks.ai/inference/v1
           generation_model: accounts/fireworks/models/mixtral-8x7b-instruct
-          function_calling_model: accounts/fireworks/models/fw-function-call-34b-v0
+          function_calling_model: accounts/fireworks/models/firefunction-v1
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Update PR description
@@ -36,7 +36,7 @@ jobs:
         with:
           openai_base_url: https://api.fireworks.ai/inference/v1
           generation_model: accounts/fireworks/models/mixtral-8x7b-instruct
-          function_calling_model: accounts/fireworks/models/fw-function-call-34b-v0
+          function_calling_model: accounts/fireworks/models/firefunction-v1
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Create PR release note

--- a/.github/workflows/test-update-pr.yml
+++ b/.github/workflows/test-update-pr.yml
@@ -17,8 +17,8 @@ jobs:
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Generate PR description
-        uses: vblagoje/auto-pr@main
-        id: auto-pr
+        uses: vblagoje/pr-auto@v1
+        id: pr-auto-id
         with:
           openai_base_url: https://api.fireworks.ai/inference/v1
           generation_model: accounts/fireworks/models/mixtral-8x7b-instruct
@@ -26,13 +26,13 @@ jobs:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Update PR description
-        uses: vblagoje/update-pr@main
+        uses: vblagoje/update-pr@v1
         with:
-          pr-body: ${{steps.auto-pr.outputs.pr-text}}
+          pr-body: ${{steps.pr-auto-id.outputs.pr-text}}
 
       - name: Generate Release Note for this PR
-        uses: vblagoje/auto-reno@main
-        id: auto-reno
+        uses: vblagoje/reno-auto@v1
+        id: reno-auto-id
         with:
           openai_base_url: https://api.fireworks.ai/inference/v1
           generation_model: accounts/fireworks/models/mixtral-8x7b-instruct
@@ -40,22 +40,7 @@ jobs:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Create PR release note
-        uses: vblagoje/create-or-update-release-note@main
+        uses: vblagoje/create-or-update-release-note@v1
         with:
-          note-name: ${{steps.auto-reno.outputs.file-name}}
-          note-content: ${{steps.auto-reno.outputs.note}}
-
-  find-pr-release-note-on-opened-pr:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-
-      - name: Find PR release note
-        uses: vblagoje/find-pr-release-note@main
-        id: find-pr-release-note
-
-      - name: Echo PR release note
-        run: echo "I found this release note ${{ steps.find-release-note-id.outputs.note-name }}"
-
-      - name: Echo PR release note without hash
-        run: echo "I found this release note ${{ steps.find-release-note-id.outputs.note-name-without-hash }}"
+          note-name: ${{steps.reno-auto-id.outputs.file-name}}
+          note-content: ${{steps.reno-auto-id.outputs.note}}

--- a/.github/workflows/test-update-pr.yml
+++ b/.github/workflows/test-update-pr.yml
@@ -20,6 +20,9 @@ jobs:
         uses: vblagoje/auto-pr@main
         id: auto-pr
         with:
+          openai_base_url: https://api.fireworks.ai/inference/v1
+          generation_model: accounts/fireworks/models/mixtral-8x7b-instruct
+          function_calling_model: accounts/fireworks/models/fw-function-call-34b-v0
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Update PR description
@@ -31,6 +34,9 @@ jobs:
         uses: vblagoje/auto-reno@main
         id: auto-reno
         with:
+          openai_base_url: https://api.fireworks.ai/inference/v1
+          generation_model: accounts/fireworks/models/mixtral-8x7b-instruct
+          function_calling_model: accounts/fireworks/models/fw-function-call-34b-v0
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Create PR release note

--- a/releasenotes/notes/update-pr-workflow-v1-251ac37c657c80ae.yaml
+++ b/releasenotes/notes/update-pr-workflow-v1-251ac37c657c80ae.yaml
@@ -1,0 +1,4 @@
+---
+features:
+ - |
+   Update the PR workflow to use vblagoje/pr-auto@v1, vblagoje/update-pr@v1, and vblagoje/reno-auto@v1 for generating PR descriptions, updating them, and creating release notes. Also, update the openai API keys and models.


### PR DESCRIPTION
### Why:

The motivations behind this change are to improve the reproducibility, scalability, and maintainability of the project's workflow. By updating the workflow to use specific versioned actions, it ensures that the pipeline remains consistent even as new versions are released. This update also reduces the likelihood of unintended side effects and removes the need for frequent manual updates due to breaking changes.

### What:

This Pull Request includes the following modifications:

- Action `vblagoje/auto-pr` is updated to `vblagoje/pr-auto@v1`.
- Action `vblagoje/auto-pr` is updated to `vblagoje/update-pr@v1`.
- Action `vblagoje/auto-reno` is updated to `vblagoje/reno-auto@v1`.
- Additional parameters are added to the PR update actions to enhance functionality.
- The `find-pr-release-note-on-opened-pr` job has been removed.

### How can it be used:

- This update can serve as a template for how to incorporate versioned actions in your workflow definition.
- The additional parameters provided to the updated actions can be used to enhance the generation of the PR description and release notes, leading to improved final output.
- The removal of the `find-pr-release-note-on-opened-pr` job reduces the complexity of the workflow, making it easier to maintain and update.

### How did you test it:

- Testing consisted of running the updated workflow and manually verifying the output and behavior of the updated actions.
- Tested the updated release note generation with the removal of the `find-pr-release-note-on-opened-pr` job, ensuring that it still creates a release note.
- The new versioned actions were tested with their additional parameters to ensure they are properly ingested and passed through to the OpenAI API.

### Notes for the reviewer:

- Please double-check that the updated actions' additional parameters are set correctly, and they are correctly ingested by the OpenAI API.
- Testing should be performed to ensure that the output and behavior of the updated workflow have not been adversely affected.
- If the removal of the `find-pr-release-note-on-opened-pr` job causes issues in specific applications, please consider alternative solutions that could be used in its place.

Confidence: 90%