### PR TITLE
feat: Use mixtral-8x7b-instruct and firefunction-v1 fireworks.ai models

### DIFF
--- a/.github/workflows/test-update-pr.yml
+++ b/.github/workflows/test-update-pr.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           openai_base_url: https://api.fireworks.ai/inference/v1
           generation_model: accounts/fireworks/models/mixtral-8x7b-instruct
-          function_calling_model: accounts/fireworks/models/fw-function-call-34b-v0
+          function_calling_model: accounts/fireworks/models/firefunction-v1
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Update PR description
@@ -36,7 +36,7 @@ jobs:
         with:
           openai_base_url: https://api.fireworks.ai/inference/v1
           generation_model: accounts/fireworks/models/mixtral-8x7b-instruct
-          function_calling_model: accounts/fireworks/models/fw-function-call-34b-v0
+          function_calling_model: accounts/fireworks/models/firefunction-v1
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Create PR release note

--- a/.github/workflows/test-update-pr.yml
+++ b/.github/workflows/test-update-pr.yml
@@ -17,8 +17,8 @@ jobs:
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Generate PR description
-        uses: vblagoje/auto-pr@main
-        id: auto-pr
+        uses: vblagoje/pr-auto@v1
+        id: pr-auto-id
         with:
           openai_base_url: https://api.fireworks.ai/inference/v1
           generation_model: accounts/fireworks/models/mixtral-8x7b-instruct
@@ -26,13 +26,13 @@ jobs:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Update PR description
-        uses: vblagoje/update-pr@main
+        uses: vblagoje/update-pr@v1
         with:
-          pr-body: ${{steps.auto-pr.outputs.pr-text}}
+          pr-body: ${{steps.pr-auto-id.outputs.pr-text}}
 
       - name: Generate Release Note for this PR
-        uses: vblagoje/auto-reno@main
-        id: auto-reno
+        uses: vblagoje/reno-auto@v1
+        id: reno-auto-id
         with:
           openai_base_url: https://api.fireworks.ai/inference/v1
           generation_model: accounts/fireworks/models/mixtral-8x7b-instruct
@@ -40,22 +40,7 @@ jobs:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Create PR release note
-        uses: vblagoje/create-or-update-release-note@main
+        uses: vblagoje/create-or-update-release-note@v1
         with:
-          note-name: ${{steps.auto-reno.outputs.file-name}}
-          note-content: ${{steps.auto-reno.outputs.note}}
-
-  find-pr-release-note-on-opened-pr:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-
-      - name: Find PR release note
-        uses: vblagoje/find-pr-release-note@main
-        id: find-pr-release-note
-
-      - name: Echo PR release note
-        run: echo "I found this release note ${{ steps.find-release-note-id.outputs.note-name }}"
-
-      - name: Echo PR release note without hash
-        run: echo "I found this release note ${{ steps.find-release-note-id.outputs.note-name-without-hash }}"
+          note-name: ${{steps.reno-auto-id.outputs.file-name}}
+          note-content: ${{steps.reno-auto-id.outputs.note}}

--- a/.github/workflows/test-update-pr.yml
+++ b/.github/workflows/test-update-pr.yml
@@ -20,6 +20,9 @@ jobs:
         uses: vblagoje/auto-pr@main
         id: auto-pr
         with:
+          openai_base_url: https://api.fireworks.ai/inference/v1
+          generation_model: accounts/fireworks/models/mixtral-8x7b-instruct
+          function_calling_model: accounts/fireworks/models/fw-function-call-34b-v0
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Update PR description
@@ -31,6 +34,9 @@ jobs:
         uses: vblagoje/auto-reno@main
         id: auto-reno
         with:
+          openai_base_url: https://api.fireworks.ai/inference/v1
+          generation_model: accounts/fireworks/models/mixtral-8x7b-instruct
+          function_calling_model: accounts/fireworks/models/fw-function-call-34b-v0
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Create PR release note

--- a/releasenotes/notes/pr-workflow-update-19551dcd02ced71e.yaml
+++ b/releasenotes/notes/pr-workflow-update-19551dcd02ced71e.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+ - |
+   Updated PR workflow to use vblagoje/pr-auto and vblagoje/reno-auto for generating PR description and release note.


### PR DESCRIPTION
### Why:

The motivation for this change is to update the workflow for creating a Pull Request (PR) description using the `vblagoje/pr-auto` action instead of the deprecated `vblagoje/auto-pr` action. This update also integrates the `vblagoje/reno-auto` action for generating a release note for the PR.

### What:

The following changes were made:

1. Modified the `.github/workflows/test-update-pr.yml` file by:
   - Replacing the `vblagoje/auto-pr` action with the `vblagoje/pr-auto` action.
   - Specifying the `openai_base_url`, `generation_model`, and `function_calling_model` for the `vblagoje/pr-auto` action.
   - Removing the `find-pr-release-note-on-opened-pr` job, which is no longer needed.
   - Updating the `vblagoje/update-pr` action to use the output from the `vblagoje/pr-auto` action.
   - Integrating the `vblagoje/reno-auto` action to generate a release note for the PR.

### How can it be used:

- With this update, the `vblagoje/pr-auto` action will generate a PR description, while the `vblagoje/reno-auto` action will automatically create a release note for the PR.
- This allows for a more streamlined and automated process for PR creation and release note generation.

### How did you test it:

- The changes were tested by running the updated `test-update-pr.yml` workflow, which includes the `vblagoje/pr-auto` and `vblagoje/reno-auto` actions.
- The updated workflow successfully generated the PR description and release note, indicating that the changes are valid and functional.

### Notes for the reviewer:

- Please ensure that the required `OPENAI_API_KEY` is provided in the repository's secrets.
- The `vblagoje/pr-auto` and `vblagoje/reno-auto` actions are now integrated, which eliminates the need for the `find-pr-release-note-on-opened-pr` job.
- The updated workflow enhances the efficiency of PR creation and release note generation.