### PR TITLE
Add new action

### DIFF
--- a/.github/actions/extract-committers/action.yml
+++ b/.github/actions/extract-committers/action.yml
@@ -1,0 +1,15 @@
+name: Extract Random User from Commit Logs
+description: Extracts a random user from commit logs who is also in the predefined list.
+inputs:
+  project_dir:
+    description: 'Project directory to scan for committers'
+    required: true
+  names_handles:
+    description: 'Mapping of names to GitHub handles in JSON format'
+    required: true
+outputs:
+  user:
+    description: 'The randomly selected user handle'
+runs:
+  using: 'node16'
+  main: 'index.js'

--- a/.github/actions/extract-committers/index.js
+++ b/.github/actions/extract-committers/index.js
@@ -1,0 +1,31 @@
+const { execSync } = require('child_process');
+const core = require('@actions/core');
+
+try {
+  // Get inputs from the action
+  const projectDir = core.getInput('project_dir');
+  const namesHandlesJson = core.getInput('names_handles');
+
+  // Parse the names to handles mapping from JSON input
+  const namesHandles = JSON.parse(namesHandlesJson);
+
+  // Extract committers' names from the git log
+  const result = execSync(`git log --pretty="%an" -- ${projectDir}`).toString();
+  const committers = new Set(result.trim().split('\n'));
+
+  // Filter committers based on predefined list
+  const filteredHandles = [];
+  committers.forEach(name => {
+    if (namesHandles[name]) {
+      filteredHandles.push(namesHandles[name]);
+    }
+  });
+
+  // Pick a random handle from the list
+  const randomUser = filteredHandles.length > 0 ? filteredHandles[Math.floor(Math.random() * filteredHandles.length)] : null;
+
+  // Output the randomly selected user
+  core.setOutput('user', randomUser);
+} catch (error) {
+  core.setFailed(`Action failed with error: ${error.message}`);
+}

--- a/.github/workflows/test-issue.yml
+++ b/.github/workflows/test-issue.yml
@@ -1,0 +1,25 @@
+name: Test Workflow
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  find-committers:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Extract random committer
+        uses: ./.github/actions/extract-committers
+        id: random_user
+        with:
+            project_dir: ${{github.workspace}}
+            names_handles: '{{"Vladimir Blagojevic": "vblagoje"}}'
+

--- a/releasenotes/notes/extract-random-committer-action-0ef2a8e68c38fac8.yaml
+++ b/releasenotes/notes/extract-random-committer-action-0ef2a8e68c38fac8.yaml
@@ -1,0 +1,4 @@
+---
+features:
+ - |
+   Introduces a new GitHub Action that extracts a random user from commit logs based on a predefined list. This feature aims to enhance the ability to spotlight contributors in an automated and fair manner by leveraging commit history.


### PR DESCRIPTION
### Why:
The provided changes introduce an automated mechanism to extract a random user from commit logs who has contributed to a specified directory within a repository. This process is set up to only consider a predefined list of users, ensuring that the selection is not entirely random but filtered by relevance or specific criteria. This can be beneficial for various reasons, including recognizing contributions or assigning post-commit tasks like code reviews or follow-up actions.

### What:
- A new GitHub Action has been created (`extract-committers/action.yml`) with the description, inputs (project directory and names to GitHub handles mapping), and outputs (user).
- The main script for the action (`extract-committers/index.js`) has been added, including:
  - Reading action inputs
  - Parsing the mapping from names to GitHub handles
  - Extracting committers' names from the git log
  - Filtering committers based on the predefined list
  - Picking a random user
  - Outputting the selected user
- A new GitHub Workflow (`workflows/test-issue.yml`) is introduced which triggers on pull request events and uses the extract-committers action to find and output a random user from the commit logs.

### How can it be used:
- In a workflow to recognize contributions by randomly selecting a user for shoutouts or rewards.
- To assign users to review code or to follow up on PRs based on their past contributions.
- Example usage in a workflow:
```yaml
- name: Extract random committer
  uses: ./.github/actions/extract-committers
  id: random_user
  with:
      project_dir: ${{github.workspace}}
      names_handles: '{{\"Vladimir Blagojevic\": \"vblagoje\"}}'
```

### How did you test it:
The testing process is not specified in the PR details. Standard tests should include:
- Unit tests for individual functions within the `index.js` file.
- Integration test to ensure that when the action is triggered, it successfully extracts a random committer's username.
- Edge cases, such as having no commits within the specified directory or an empty predefined list, should also be tested.

### Notes for the reviewer:
- Ensure that the `names_handles` input is in the correct JSON format and that the mapping provided is accurate and up to date.
- Review the randomness of selection logic to ensure that it's fair and unbiased.
- The workflow file only triggers on `pull_request` events of type `opened`, consider if other event types should also trigger this action.
- Verify the permissions necessary for the action to access commit logs.