### PR TITLE
Use condition for release note

### DIFF
--- a/.github/workflows/test-update-pr.yml
+++ b/.github/workflows/test-update-pr.yml
@@ -5,10 +5,30 @@ on:
     types: [opened]
 
 jobs:
+  set-reno-condition:
+    runs-on: ubuntu-latest
+    outputs:
+      generate-release-note: ${{ steps.set-output.outputs.generate-release-note }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set generate-release-note output
+        id: set-output
+        run: |
+          labels=$(jq -r '.pull_request.labels[].name' <<<"$GITHUB_EVENT")
+          if echo "$labels" | grep -q "ignore-for-release-notes"; then
+            echo "::set-output name=generate-release-note::false"
+          else
+            echo "::set-output name=generate-release-note::true"
+          fi
+        env:
+          GITHUB_EVENT: ${{ toJson(github.event) }}
+
   create-pr-release-note:
     runs-on: ubuntu-latest
+    needs: set-reno-condition
     steps:
-
       - name: Checkout Repository (even forks) to add reno note commit to it
         uses: actions/checkout@v4
         with:
@@ -29,12 +49,14 @@ jobs:
 
       - name: Generate Release Note for this PR
         uses: vblagoje/reno-auto@main
+        if: needs.set-reno-condition.outputs.generate-release-note == 'true'
         id: reno-auto-step
         with:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Create PR release note and commit it to the branch
         uses: vblagoje/create-or-update-release-note@main
+        if: needs.set-reno-condition.outputs.generate-release-note == 'true'
         with:
           note-name: ${{steps.reno-auto-step.outputs.file-name}}
           note-content: ${{steps.reno-auto-step.outputs.note}}

--- a/releasenotes/notes/conditional-release-note-generation-a8a3864ad5f46cb6.yaml
+++ b/releasenotes/notes/conditional-release-note-generation-a8a3864ad5f46cb6.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+ - |
+   Enhanced the GitHub Actions workflow for PRs to conditionally generate release notes based on the presence of the 'ignore-for-release-notes' label. This ensures that only relevant PRs have release notes generated, optimizing the workflow.


### PR DESCRIPTION
### Why:
This change addresses the need for conditional generation of release notes for Pull Requests. Specifically, it ensures that release notes are only generated for PRs that do not have the "ignore-for-release-notes" label. This refinement prevents unnecessary release note generation, enhancing workflow efficiency and repository management.

### What:
- Renamed the `create-pr-release-note` job to `set-reno-condition`.
- Added steps to checkout the code and determine if the release note should be generated based on PR labels.
- Introduced an output parameter `generate-release-note` to conditionally control the execution of the release note generation and creation steps.
- Modified the `create-pr-release-note` job to depend on the output of the `set-reno-condition` job.
- Ensured the release note generation and commit steps are conditional on the `generate-release-note` output.

### How can it be used:
- Automatically generate release notes for PRs without the "ignore-for-release-notes" label:
  ```
  labels=$(jq -r '.pull_request.labels[].name' <<<"$GITHUB_EVENT")
  if echo "$labels" | grep -q "ignore-for-release-notes"; then
    echo "::set-output name=generate-release-note::false"
  else
    echo "::set-output name=generate-release-note::true"
  fi
  ```
- Steps to check out the repository and conditionally generate release notes:
  ```
  - name: Checkout Repository (even forks) to add reno note commit to it
    uses: actions/checkout@v4

  - name: Generate Release Note for this PR
    uses: vblagoje/reno-auto@main
    if: needs.set-reno-condition.outputs.generate-release-note == 'true'
  ```
- Commit the release note to the branch only if release note generation is needed:
  ```
  - name: Create PR release note and commit it to the branch
    uses: vblagoje/create-or-update-release-note@main
    if: needs.set-reno-condition.outputs.generate-release-note == 'true'
  ```

### How did you test it:
- Manual testing by creating example PRs with and without the "ignore-for-release-notes" label, validating that the release note generation step is skipped or executed accordingly.
- Verified the presence and correctness of the `generate-release-note` output parameter impacting downstream job execution.

### Notes for the reviewer:
- Ensure the labels used in PRs are correctly managed to utilize this conditional execution effectively.
- Pay attention to the introduction of new environment variables and output parameters and their integration within the workflow.
- Check for any potential impact on existing workflows and confirm the presence of required secrets (`OPENAI_API_KEY`).