### PR TITLE
Minor fixes

### DIFF
--- a/.github/workflows/test-update-pr.yml
+++ b/.github/workflows/test-update-pr.yml
@@ -10,9 +10,6 @@ jobs:
     outputs:
       generate-release-note: ${{ steps.set-output.outputs.generate-release-note }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
       - name: Set generate-release-note output
         id: set-output
         run: |
@@ -37,25 +34,25 @@ jobs:
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Generate PR description for this PR and update the PR web page
-        uses: vblagoje/pr-auto@main
+        uses: vblagoje/pr-auto@v1
         id: pr-auto-step
         with:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Update PR description
-        uses: vblagoje/update-pr@main
+        uses: vblagoje/update-pr@v1
         with:
           pr-body: ${{steps.pr-auto-step.outputs.pr-text}}
 
       - name: Generate Release Note for this PR
-        uses: vblagoje/reno-auto@main
+        uses: vblagoje/reno-auto@v1
         if: needs.set-reno-condition.outputs.generate-release-note == 'true'
         id: reno-auto-step
         with:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Create PR release note and commit it to the branch
-        uses: vblagoje/create-or-update-release-note@main
+        uses: vblagoje/create-or-update-release-note@v1
         if: needs.set-reno-condition.outputs.generate-release-note == 'true'
         with:
           note-name: ${{steps.reno-auto-step.outputs.file-name}}

--- a/releasenotes/notes/update-workflow-versioning-ce7b8fc26ffb6dab.yaml
+++ b/releasenotes/notes/update-workflow-versioning-ce7b8fc26ffb6dab.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+ - |
+   Updated GitHub Actions workflow for better versioning by changing actions usage from @main to specific versions (@v1) to ensure more stable and predictable builds.


### PR DESCRIPTION
### Why:
The GitHub Actions workflow needed updates to ensure compatibility with versioned action references. By specifying versions, the stability and predictability of the CI/CD process are improved, mitigating potential disruptions from changes in external actions.

### What:
- Removed the redundant `Checkout code` step.
- Changed action references from `@main` to specific versions `@v1` for several steps:
  - `vblagoje/pr-auto`
  - `vblagoje/update-pr`
  - `vblagoje/reno-auto`
  - `vblagoje/create-or-update-release-note`

### How can it be used:
These changes stabilize the CI/CD workflow by ensuring that specific versions of actions are used, preventing unexpected breakages due to changes in the codebase of these actions:
- The workflow will now use the explicitly defined versions (`v1`) of the actions instead of the latest `main`, making it more predictable and stable.

### How did you test it:
Testing can be confirmed through:
- Running the updated workflow on a range of test pull requests to ensure that the correct actions are executed.
- Verifying that the outputs and behaviors of the actions remain as expected after specifying the versions.

### Notes for the reviewer:
- Confirm that all specified version changes (`@v1`) are available and correctly implemented in their repositories.
- Ensure no additional steps were affected by the removal of the `Checkout code` step.
- Pay special attention to the functionality of generated release notes and PR updates, which rely heavily on the version-specific behavior of the actions.