### PR TITLE
Rework jobs slightly

### DIFF
--- a/.github/workflows/test-update-pr.yml
+++ b/.github/workflows/test-update-pr.yml
@@ -5,6 +5,20 @@ on:
     types: [opened]
 
 jobs:
+  generate-pr-description:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Generate PR description for this PR and update the PR web page
+      uses: vblagoje/pr-auto@v1
+      id: pr-auto-step
+      with:
+        openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+
+    - name: Update PR description
+      uses: vblagoje/update-pr@v1
+      with:
+        pr-body: ${{steps.pr-auto-step.outputs.pr-text}}
+
   set-reno-condition:
     runs-on: ubuntu-latest
     outputs:
@@ -26,26 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: set-reno-condition
     steps:
-      # intentionally doing this step first to speed up PR text generation and improve UX
-      - name: Generate PR description for this PR and update the PR web page
-        uses: vblagoje/pr-auto@v1
-        id: pr-auto-step
-        with:
-          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
-
-      - name: Update PR description
-        uses: vblagoje/update-pr@v1
-        with:
-          pr-body: ${{steps.pr-auto-step.outputs.pr-text}}
-
-      # now checkout the repo to add the release note commit to it (if needed)
-      - name: Checkout Repository (even forks) to add reno note commit to it
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
-
       - name: Generate Release Note for this PR
         uses: vblagoje/reno-auto@v1
         if: needs.set-reno-condition.outputs.generate-release-note == 'true'


### PR DESCRIPTION
### Why:
The existing workflow for updating a pull request (PR) description in `.github/workflows/test-update-pr.yml` operates inefficiently by incorporating the PR description generation and update steps within a later job. This slows down the process and negatively impacts the user experience (UX). The changes aim to optimize the workflow by restructuring these steps for a more efficient PR description update process.

### What:
- Introduced a new job `generate-pr-description` that runs on `ubuntu-latest` to handle the PR description generation and update steps, improving the order and efficiency.
- Deleted duplicate steps from the `set-release-note` job that were previously responsible for generating and updating the PR description.
- Adjusted the existing set-release-note job to streamline its operations by removing redundant steps.

### How can it be used:
- The new `generate-pr-description` job now runs early in the workflow to generate and update the PR description efficiently.
- This improves the overall workflow execution time and enhances UX by promptly updating and displaying the PR description.

*Example code from the modifications*:
```yaml
jobs:
  generate-pr-description:
    runs-on: ubuntu-latest
    steps:
    - name: Generate PR description for this PR and update the PR web page
      uses: vblagoje/pr-auto@v1
      id: pr-auto-step
      with:
        openai_api_key: ${{ secrets.OPENAI_API_KEY }}
    - name: Update PR description
      uses: vblagoje/update-pr@v1
      with:
        pr-body: ${{steps.pr-auto-step.outputs.pr-text}}
```

### How did you test it:
- The changes should be tested by running the updated GitHub Actions workflow to ensure it completes without errors and correctly updates the PR description.
- Verify that the `generate-pr-description` job executes as expected and the PR description is updated promptly.
- Confirm that the overall workflow execution time improves, as intended.

### Notes for the reviewer:
- Ensure that the new `generate-pr-description` job efficiently replaces the previously duplicated steps.
- Pay attention to the overall workflow execution to verify performance improvements.
- Validate that no functionality is lost with the removal of steps from the `set-release-note` job.