### PR TITLE
Fine tune instructions

### DIFF
--- a/.github/workflows/test-update-pr.yml
+++ b/.github/workflows/test-update-pr.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           issue-number: ${{github.event.pull_request.number}}
           body: |
-            We use reno release notes to describe the code changes in this PR. Here is what you need to do:
+            We use reno release [notes](https://docs.openstack.org/reno/latest/) to describe the code changes in this PR. Here is what you need to do:
             1. Install reno via `pip install reno` (of course only once per venv)
             2. Issue this command in your terminal from the project root: `reno new ${{steps.reno-auto-step.outputs.file-name}}`
             3. This command will generate a new release note file in the `releasenotes/notes` directory.


### PR DESCRIPTION
### Why:
The change addresses the need to provide clearer instructions within the GitHub Actions workflow for generating release notes. The previous instructions lacked a direct reference to the Reno documentation, which could cause confusion for contributors unfamiliar with Reno.

### What:
- Added a hyperlink to the Reno documentation within the workflow instructions to enhance clarity and provide immediate access to relevant information.

### How can it be used:
Contributors can follow these improved instructions when adding release notes:
- Access the Reno documentation directly via the provided link.
- Install Reno using `pip install reno`.
- Generate new release notes using the `reno new` command from the project root.

### How did you test it:
Ensured the link syntax is correct and verified that it directs to the appropriate Reno documentation page. The effectiveness of the change primarily lies in the documentation, which doesn't impact the execution of the workflow itself.

### Notes for the reviewer:
Ensure the link is correctly formatted and directs to the intended Reno documentation page. This minor documentation update does not alter the workflow's operation but improves its usability for contributors. The exact location of usage is within the workflow file `.github/workflows/test-update-pr.yml`.