### PR TITLE
More fine tuning

### DIFF
--- a/.github/workflows/test-update-pr.yml
+++ b/.github/workflows/test-update-pr.yml
@@ -53,13 +53,17 @@ jobs:
         with:
           issue-number: ${{github.event.pull_request.number}}
           body: |
-            We use reno release [notes](https://docs.openstack.org/reno/latest/) to describe the code changes in this PR. Here is what you need to do:
-            1. Install reno via `pip install reno` (of course only once per venv)
-            2. Issue this command in your terminal from the project root: `reno new ${{steps.reno-auto-step.outputs.file-name}}`
+            We use Reno release notes (https://docs.openstack.org/reno/latest/) to describe the code changes in this PR. Follow these steps:
+
+            1. Install Reno via `pip install reno` (only once per virtual environment)
+            2. Run this command in your terminal from the project root:
+            ```
+            reno new ${{steps.reno-auto-step.outputs.file-name}}
+            ```
             3. This command will generate a new release note file in the `releasenotes/notes` directory.
-            Paste this release note below in that file:
+               Paste the following release note text into that file:
             ```
             ${{steps.reno-auto-step.outputs.note}}
             ```
-            4. Verify the release note text, adjust it if needed, and save this file
-            5. Add this file to the commit and push to the branch
+            4. Review the release note text, adjust if needed, and save the file
+            5. Add this file to your commit and push it to the branch


### PR DESCRIPTION
### Why:
The existing instructions in the CI workflow for generating release notes were found to be unclear and slightly formatted incorrect. This led to occasional misunderstandings and potential errors when contributors follow the process. The modification aims to improve clarity, readability, and correctness of the instructions, ensuring contributors can generate release notes correctly and efficiently.

### What:
- Improved the clarity and readability of the instructions for generating release notes.
- Added Markdown formatting to enhance visual comprehension.
- Corrected minor grammatical issues to ensure clear communication.

### How can it be used:
- Contributors can follow the refined steps to generate release notes for their PRs.
- Example usage:
  1. Install Reno via `pip install reno` (only once per virtual environment)
  2. Run the following command from the project root:
        reno new ${{steps.reno-auto-step.outputs.file-name}}
  3. This generates a new release note file in the `releasenotes/notes` directory.
  4. Paste the provided release note text into the new file.
  5. Review the text, adjust if needed, save the file, add it to your commit, and push it to the branch.

### How did you test it:
- The changes were tested by following the updated instructions in a test environment to ensure they are clear and produce the expected outcome.
- Verified that the formatted Markdown renders correctly in the GitHub UI.

### Notes for the reviewer:
- Confirm the rendered format of the instructions in the GitHub UI.
- Ensure the patch maintains the intended functionality of auto-generating release note file names and injecting note content.
- Pay special attention to the clarity and completeness of the revised instructions to ensure no steps are ambiguous.