### PR TITLE
Better workflow names

### DIFF
--- a/.github/workflows/test-update-pr.yml
+++ b/.github/workflows/test-update-pr.yml
@@ -40,14 +40,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: set-reno-condition
     steps:
-      - name: Generate Release Note for this PR
+      - name: Generate release note for this PR
         uses: vblagoje/reno-auto@v1
         if: needs.set-reno-condition.outputs.generate-release-note == 'true'
         id: reno-auto-step
         with:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
-      - name: Create PR comment
+      - name: Create PR comment with release note instructions
         uses: peter-evans/create-or-update-comment@v4
         if: needs.set-reno-condition.outputs.generate-release-note == 'true'
         with:


### PR DESCRIPTION
### Why:
There was a need for better clarity within the GitHub Actions workflow, specifically in naming conventions. Clearer step names improve readability and maintainability, helping contributors understand the purpose of each step without needing to delve into the details.

### What:
- Renamed "Generate Release Note for this PR" to "Generate release note for this PR"
- Renamed "Create PR comment" to "Create PR comment with release note instructions"

### How can it be used:
- The updated workflow steps will now more clearly convey their purpose:
  - "Generate release note for this PR" assists with generating the release notes contingent on certain conditions.
  - "Create PR comment with release note instructions" highlights the step’s role in commenting with specific instructions related to release notes.

### How did you test it:
- Changes were applied directly to the workflow YAML file. The GitHub Actions workflow will run these steps automatically in the context of a pull request, validating the name changes don't affect the workflow execution. This ensures that the renaming doesn't cause any functional issues and that each step executes as expected.

### Notes for the reviewer:
- Review the clarity provided by the new step names and ensure they align with the workflow's overall purpose.
- Ensure that other parts of the documentation or workflows referencing these steps are also updated if necessary.